### PR TITLE
Fix inconsistent update for template x-if (issue #2803)

### DIFF
--- a/packages/alpinejs/src/scheduler.js
+++ b/packages/alpinejs/src/scheduler.js
@@ -2,6 +2,7 @@
 let flushPending = false
 let flushing = false
 let queue = []
+let lastFlushedIndex = -1
 
 export function scheduler (callback) { queueJob(callback) }
 
@@ -13,7 +14,7 @@ function queueJob(job) {
 export function dequeueJob(job) {
     let index = queue.indexOf(job)
 
-    if (index !== -1) queue.splice(index, 1)
+    if (index !== -1 && index > lastFlushedIndex) queue.splice(index, 1)
 }
 
 function queueFlush() {
@@ -30,9 +31,11 @@ export function flushJobs() {
 
     for (let i = 0; i < queue.length; i++) {
         queue[i]()
+        lastFlushedIndex = i
     }
 
     queue.length = 0
+    lastFlushedIndex = -1
 
     flushing = false
 }


### PR DESCRIPTION
## Context
This PR implements a fix for a bug in which some `template x-if` elements are rendered inconsistently; 
i.e. given two `template x-if` with an identical condition, one is shown while the other is not.  

This is a reproducible bug discussed in [Discussion #2802](https://github.com/alpinejs/alpine/discussions/2802) and in [Issue #2803](https://github.com/alpinejs/alpine/issues/2803). Based on the CodePen posted in the Issue thread,
I prepared a minimal reproducible example: https://codepen.io/ferranconde/pen/OJEzeLL?editors=1000

According to [this comment](https://github.com/alpinejs/alpine/issues/2803#issuecomment-1128658513), the bug arises from the interaction of `flushJobs()` and `dequeueJob()` in `scheduler.js`.  

Given a tag `<template x-if="condition">`, if `condition` becomes `false`, a job will be added to the queue of jobs to flush. 
When processed, that job will call `hide()`, where, in turn, the `_x_undoIf()` method dequeues all the reactive effects of the element's children.  

The issue is that, depending on the order in which these jobs were added to the queue,`dequeueJob(j)` may attempt to remove the job at position `j` from the queue, while that job had already been visited.  

This effectively causes some jobs to be skipped, since the current index `i` used in `flushJobs()` when looping over the queue does not change.  

The following diagram outlines how the error happens in the CodePen's reproducible example:
![Diagram outlining the sequence of jobs in the reproducible example](https://i.gyazo.com/cba3ae46234d06c395b833dd11165bae.png)

## Fix
The proposed implementation keeps track of the last flushed index. 
In `dequeueJob`, a job is only dequeued if the job's index in the queue is greater than said last flushed index.  
This prevents mutating the queue in a way that would cause the inconsistencies to be triggered.
