### PR TITLE
Fix Alpine.js becoming unresponsive after uncaught exception in reactive effect callback

### DIFF
--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -39,11 +39,9 @@ export function normalEvaluator(el, expression) {
 
     let dataStack = [overriddenMagics, ...closestDataStack(el)]
 
-    if (typeof expression === 'function') {
-        return generateEvaluatorFromFunction(dataStack, expression)
-    }
-
-    let evaluator = generateEvaluatorFromString(dataStack, expression, el)
+    let evaluator = (typeof expression === 'function')
+        ? generateEvaluatorFromFunction(dataStack, expression)
+        : generateEvaluatorFromString(dataStack, expression, el)
 
     return tryCatch.bind(null, el, expression, evaluator)
 }

--- a/packages/alpinejs/src/scheduler.js
+++ b/packages/alpinejs/src/scheduler.js
@@ -28,11 +28,13 @@ export function flushJobs() {
     flushPending = false
     flushing = true
 
-    for (let i = 0; i < queue.length; i++) {
-        queue[i]()
+    try {
+        for (let i = 0; i < queue.length; i++) {
+            queue[i]()
+        }
+    } finally {
+        queue.length = 0
+
+        flushing = false
     }
-
-    queue.length = 0
-
-    flushing = false
 }

--- a/packages/alpinejs/src/scheduler.js
+++ b/packages/alpinejs/src/scheduler.js
@@ -28,13 +28,11 @@ export function flushJobs() {
     flushPending = false
     flushing = true
 
-    try {
-        for (let i = 0; i < queue.length; i++) {
-            queue[i]()
-        }
-    } finally {
-        queue.length = 0
-
-        flushing = false
+    for (let i = 0; i < queue.length; i++) {
+        queue[i]()
     }
+
+    queue.length = 0
+
+    flushing = false
 }


### PR DESCRIPTION
# Fix Alpine.js unresponsive after uncaught exception in reactive effect callback

## Context
Alpine.js executes reactive effects when the application state changes. Some of these reactive effects involve executing
custom methods defined by the application developers (e.g. methods for `x-show`, `x-text`) and thus may contain bugs.  
When one of these callbacks raises an unexpected exception, the whole application becomes unresponsive because Alpine does not handle this gracefully.  

In the following reproducible example (https://codepen.io/ferranconde/pen/PoaQJaX?editors=1010), 
there's a component whose `x-show` method features a faulty implementation.  
After clicking on the orange button, any other component, e.g. the counter text + button, stop working.  
The application is in an unrecoverable state.

The issue is that, in `scheduler.js:flushJobs()`, if there is an uncaught exception in the `for` loop that traverses
the job queue, the `flushing` flag is not properly reset. On any subsequent state changes, the condition for `queueFlush()`
to call `flushJobs` will never be `true` anymore. A page reload is then needed.

## Fix
The proposed implementation wraps the for loop in `flushJobs()` in a try-finally, where the queue and the `flushing` flag
are properly reset, even if a job callback failed due to a developer's faulty implementation.   
This ensures the application is still responsive and users can still perform other actions.

## Doubts
I was unsure whether the try-finally should wrap each loop iteration or the whole loop. Since the jobs may have
dependencies between them, I was worried that skipping crashing jobs might result in an inconsistent application state.  
I think wrapping the entire loop is closer to the current behavior but at least provides some degree of responsiveness.
